### PR TITLE
Simplified gradle-nexus-staging-plugin configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         classpath 'com.ofg:uptodate-gradle-plugin:1.1.0'
         if (!version.contains('SNAPSHOT')) {
             classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:+'
-            classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.1"
+            classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
         }
     }
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -85,6 +85,3 @@ bintray {
 	}
 }
 
-nexusStaging {
-	packageGroup = "com.blogspot.toomuchcoding"
-}


### PR DESCRIPTION
Starting since version 0.5.3 project.group is used by default.