### PR TITLE
chore: Remove JDK7 from TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ script: ./gradlew clean build
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
 
 script:
 - ./gradlew clean build -PspockVersion=0.7-groovy-2.0 && ./gradlew clean build -PspockVersion=1.0-groovy-2.3


### PR DESCRIPTION
JDK7 is no longer available in Travis https://github.com/travis-ci/travis-ci/issues/7884