### PR TITLE
[#29] Restore compatibility with Groovy 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 
-		<groovy.version>3.0.8</groovy.version>
-		<spock.version>2.0-groovy-3.0</spock.version>
+		<groovy.version>2.5.21</groovy.version>
+		<spock.version>2.0-groovy-2.5</spock.version>
 		<objenesis.version>3.2</objenesis.version>
 		<byte-buddy.version>1.11.0</byte-buddy.version>
 		<junit.version>4.13.1</junit.version>


### PR DESCRIPTION
Fixes: #29

Just compiling against Groovy 2.5 again makes the extension compatible again.

