### PR TITLE
Updated to Groovy 4 to support Spring Boot 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.blogspot.toomuchcoding</groupId>
 	<artifactId>spock-subjects-collaborators-extension</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<name>spock-subjects-collaborators-extension</name>
 	<description>Spock extension that allows you to inject Collaborators into Subjects. Bases on Mockito's @InjectMocks functionality</description>
 	<url>https://github.com/marcingrzejszczak/spock-subjects-collaborators-extension</url>
@@ -71,12 +71,12 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 
-		<groovy.version>2.5.21</groovy.version>
-		<spock.version>2.0-groovy-2.5</spock.version>
+		<groovy.version>4.0.11</groovy.version>
+		<spock.version>2.3-groovy-4.0</spock.version>
 		<objenesis.version>3.2</objenesis.version>
 		<byte-buddy.version>1.11.0</byte-buddy.version>
 
-		<gmavenplus-plugin.version>1.12.1</gmavenplus-plugin.version>
+		<gmavenplus-plugin.version>2.1.0</gmavenplus-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
 		<maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
 		<maven-source-plugin.version>3.2.1</maven-source-plugin.version>
@@ -86,7 +86,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.codehaus.groovy</groupId>
+			<groupId>org.apache.groovy</groupId>
 			<artifactId>groovy</artifactId>
 			<version>${groovy.version}</version>
 			<scope>compile</scope>
@@ -163,7 +163,7 @@
 				</configuration>
 				<dependencies>
 					<dependency>
-						<groupId>org.codehaus.groovy</groupId>
+						<groupId>org.apache.groovy</groupId>
 						<artifactId>groovy-groovydoc</artifactId>
 						<version>${groovy.version}</version>
 					</dependency>


### PR DESCRIPTION
Migrated to Groovy 4 so it can be used with `Spring Boot 3`:

* Bump version to `3.0.0` as this is a major update
* Updated to use the new `org.apache.groovy`
* Updated Groovy to `4.0.11`
* Updated Spock to `2.3-groovy-4.0`
* Updated GMavenPlus to `2.1.0`